### PR TITLE
Migrate to using Firebase Web SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ import "@joinflux/firebase-analytics";
 import { Plugins } from "@capacitor/core";
 
 const { FirebaseAnalytics } = Plugins;
+import { app } from "./utils/firebase";
+
+/**
+ * This must be done to start the plugin.
+ */
+FirebaseAnalytics.initializeFirebase(app);
 
 /**
  * Platform: Web/Android/iOS

--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@
 
 ## Maintainers
 
-| Maintainer    | GitHub                                      | Social                                           |
-| ------------- | ------------------------------------------- | ------------------------------------------------ |
-| Priyank Patel | [priyankpat](https://github.com/priyankpat) | [@priyankpat\_](https://twitter.com/priyankpat_) |
-| Stewan Silva  | [stewwan](https://github.com/stewwan)       | [@StewanSilva](https://twitter.com/StewanSilva)  |
+| Maintainer      | GitHub                                |
+| --------------- | ------------------------------------- |
+| Gustavo Horisch | [gugahoi](https://github.com/gugahoi) |
 
 Maintenance Status: Actively Maintained
 
@@ -79,17 +78,6 @@ public class MainActivity extends BridgeActivity {
 
 No configuration is required for this plugin.
 
-## Examples
-
-[Click here](https://github.com/priyankpat/capacitor-plugins-example/tree/firebase-analytics) for an example on how to implement this plugin.
-
-You can also clone the repository:
-
-```bash
-git clone https://github.com/priyankpat/capacitor-plugins-example
-git checkout -b firebase-analytics
-```
-
 ## Supported methods
 
 | Name                      | Android | iOS | Web |
@@ -114,22 +102,6 @@ import "@joinflux/firebase-analytics";
 import { Plugins } from "@capacitor/core";
 
 const { FirebaseAnalytics } = Plugins;
-
-/**
- * Platform: Web
- * Configure and initialize the firebase app.
- * @param options - firebase web app configuration options
- * */
-FirebaseAnalytics.initializeFirebase({
-  apiKey: "...",
-  authDomain: "...",
-  databaseURL: "...",
-  projectId: "...",
-  storageBucket: "...",
-  messagingSenderId: "...",
-  appId: "...",
-  measurementId: "...",
-});
 
 /**
  * Platform: Web/Android/iOS

--- a/android/src/main/java/com/getcapacitor/community/firebaseanalytics/FirebaseAnalytics.java
+++ b/android/src/main/java/com/getcapacitor/community/firebaseanalytics/FirebaseAnalytics.java
@@ -41,11 +41,6 @@ public class FirebaseAnalytics extends Plugin {
   @PluginMethod
   public void setUserId(PluginCall call) {
     try {
-      if (mFirebaseAnalytics == null) {
-        call.error(MISSING_REF_MSSG);
-        return;
-      }
-
       if (!call.hasOption("userId")) {
         call.error("userId property is missing");
         return;
@@ -66,11 +61,6 @@ public class FirebaseAnalytics extends Plugin {
   @PluginMethod
   public void setUserProperty(PluginCall call) {
     try {
-      if (mFirebaseAnalytics == null) {
-        call.error(MISSING_REF_MSSG);
-        return;
-      }
-
       if (!call.hasOption("name")) {
         call.error("name property is missing");
         return;
@@ -98,11 +88,6 @@ public class FirebaseAnalytics extends Plugin {
   @PluginMethod
   public void getAppInstanceId(PluginCall call) {
     try {
-      if (mFirebaseAnalytics == null) {
-        call.error(MISSING_REF_MSSG);
-        return;
-      }
-
       String instanceId = mFirebaseAnalytics.getAppInstanceId().toString();
 
       if (instanceId.isEmpty()) {
@@ -126,11 +111,6 @@ public class FirebaseAnalytics extends Plugin {
   @PluginMethod
   public void setScreenName(final PluginCall call) {
     try {
-      if (mFirebaseAnalytics == null) {
-        call.error(MISSING_REF_MSSG);
-        return;
-      }
-
       if (!call.hasOption("screenName")) {
         call.error("screenName property is missing");
         return;
@@ -167,11 +147,6 @@ public class FirebaseAnalytics extends Plugin {
   @PluginMethod
   public void reset(PluginCall call) {
     try {
-      if (mFirebaseAnalytics == null) {
-        call.error(MISSING_REF_MSSG);
-        return;
-      }
-
       mFirebaseAnalytics.resetAnalyticsData();
       call.success();
     } catch (Exception ex) {
@@ -187,11 +162,6 @@ public class FirebaseAnalytics extends Plugin {
   @PluginMethod
   public void logEvent(PluginCall call) {
     try {
-      if (mFirebaseAnalytics == null) {
-        call.error(MISSING_REF_MSSG);
-        return;
-      }
-
       if (!call.hasOption("name")) {
         call.error("name property is missing");
         return;
@@ -236,11 +206,6 @@ public class FirebaseAnalytics extends Plugin {
    */
   @PluginMethod
   public void setCollectionEnabled(PluginCall call) {
-    if (mFirebaseAnalytics == null) {
-      call.error(MISSING_REF_MSSG);
-      return;
-    }
-
     boolean enabled = call.getBoolean("enabled", false);
 
     mFirebaseAnalytics.setAnalyticsCollectionEnabled(enabled);
@@ -255,11 +220,6 @@ public class FirebaseAnalytics extends Plugin {
   @Deprecated
   @PluginMethod
   public void enable(PluginCall call) {
-    if (mFirebaseAnalytics == null) {
-      call.error(MISSING_REF_MSSG);
-      return;
-    }
-
     mFirebaseAnalytics.setAnalyticsCollectionEnabled(true);
     call.success();
   }
@@ -272,11 +232,6 @@ public class FirebaseAnalytics extends Plugin {
   @Deprecated
   @PluginMethod
   public void disable(PluginCall call) {
-    if (mFirebaseAnalytics == null) {
-      call.error(MISSING_REF_MSSG);
-      return;
-    }
-
     mFirebaseAnalytics.setAnalyticsCollectionEnabled(false);
     call.success();
   }
@@ -287,25 +242,9 @@ public class FirebaseAnalytics extends Plugin {
    */
   @PluginMethod
   public void setSessionTimeoutDuration(PluginCall call) {
-    if (mFirebaseAnalytics == null) {
-      call.error(MISSING_REF_MSSG);
-      return;
-    }
-
     int duration = call.getInt("duration", 1800);
 
     mFirebaseAnalytics.setSessionTimeoutDuration(duration);
-    call.success();
-  }
-
-  /**
-   * Does nothing in Android as initialization happens automatically on load.
-   * This method is only here to maintain a consistent API accross all
-   * platforms.
-   * @param call: options - duration: duration of inactivity
-   */
-  @PluginMethod
-  public void initializeFirebase(PluginCall call) {
     call.success();
   }
 }

--- a/android/src/main/java/com/getcapacitor/community/firebaseanalytics/FirebaseAnalytics.java
+++ b/android/src/main/java/com/getcapacitor/community/firebaseanalytics/FirebaseAnalytics.java
@@ -35,6 +35,19 @@ public class FirebaseAnalytics extends Plugin {
   }
 
   /**
+   * Initializes the firebase app.
+   * @param call: dismissed
+   *
+   * @web only.
+   *
+   * This is a helper method to provide common APIs accross platforms.
+   */
+  @PluginMethod
+  public void initializeFirebase(PluginCall call) {
+    call.success();
+  }
+
+  /**
    * Sets the user ID property.
    * @param call - userId: unique identifier of the user to log
    */

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -2,6 +2,7 @@
 #import <Capacitor/Capacitor.h>
 
 CAP_PLUGIN(FirebaseAnalytics, "FirebaseAnalytics",
+           CAP_PLUGIN_METHOD(initializeFirebase, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setUserId, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setUserProperty, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getAppInstanceId, CAPPluginReturnPromise);

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -10,7 +10,6 @@ CAP_PLUGIN(FirebaseAnalytics, "FirebaseAnalytics",
            CAP_PLUGIN_METHOD(logEvent, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setCollectionEnabled, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setSessionTimeoutDuration, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(initializeFirebase, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(enable, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(disable, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -14,6 +14,15 @@ public class FirebaseAnalytics: CAPPlugin {
     }
     
     
+    /// Initializes the firebase app. 
+    /// Param call: dismissed
+    ///
+    /// @web only. 
+    /// This is a helper method to provide common APIs accross platforms.
+    @objc func initializeFirebase(_ call: CAPPluginCall) {
+        call.success()
+    }
+    
     /// Sets the user ID property.
     /// - Parameter call: userId - unique identifier of the user to log
     @objc func setUserId(_ call: CAPPluginCall) {

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -120,15 +120,6 @@ public class FirebaseAnalytics: CAPPlugin {
         Analytics.setSessionTimeoutInterval(TimeInterval(duration))
     }
 
-
-    // initializeFirebase does nothing in iOS as initialization happens
-    // automatically. The method is still available to maintain a consistent
-    // api accross all platforms.
-    @objc func initializeFirebase(_ call: CAPPluginCall) {
-        print("FirebaseAnalytics: initializeFirebase noop")
-        call.success()
-    }
-
     /// Deprecated - use setCollectionEnabled instead
     /// Enable analytics collection for this app on this device.
     /// - Parameter call

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@joinflux/firebase-analytics",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,409 @@
       "integrity": "sha512-XKYU67ZM+yY4/vDJ3ZVfs+phjtWK8TcKwq75fGoxB9PKXuCmMi5bihPuA3Xs/sIFXuozpnaYnspp0eTRJ7bG0w==",
       "dev": true
     },
+    "@firebase/analytics": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.9.tgz",
+      "integrity": "sha512-G0PkfMq/4tpDXwk/S2LKrXUWiz5tpQ6o2Lf6esgdEcDLpimPl32TrioNkDEDz8Xp0mzpY04UKwvYjT5xuzoKug==",
+      "requires": {
+        "@firebase/analytics-types": "0.4.0",
+        "@firebase/component": "0.4.1",
+        "@firebase/installations": "0.4.25",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@firebase/analytics-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.4.0.tgz",
+      "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA=="
+    },
+    "@firebase/app": {
+      "version": "0.6.20",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.20.tgz",
+      "integrity": "sha512-5zstJ3Cxw9H5cxfdaAhCH7WHVaRLPhCcgVNwKp6dWeTx2QkIdNvHainX8Vr2RaZchw4MxRjkPfwNVOaq2oFStQ==",
+      "requires": {
+        "@firebase/app-types": "0.6.2",
+        "@firebase/component": "0.4.1",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "1.0.0",
+        "dom-storage": "2.1.0",
+        "tslib": "^2.1.0",
+        "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@firebase/app-types": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
+      "integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw=="
+    },
+    "@firebase/auth": {
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.4.tgz",
+      "integrity": "sha512-zgHPK6/uL6+nAyG9zqammHTF1MQpAN7z/jVRLYkDZS4l81H08b2SzApLbRfW/fmy665xqb5MK7sVH0V1wsiCNw==",
+      "requires": {
+        "@firebase/auth-types": "0.10.2"
+      }
+    },
+    "@firebase/auth-interop-types": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz",
+      "integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw=="
+    },
+    "@firebase/auth-types": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.2.tgz",
+      "integrity": "sha512-0GMWVWh5TBCYIQfVerxzDsuvhoFpK0++O9LtP3FWkwYo7EAxp6w0cftAg/8ntU1E5Wg56Ry0b6ti/YGP6g0jlg=="
+    },
+    "@firebase/component": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.4.1.tgz",
+      "integrity": "sha512-f0IbIsoe33QzOj554rmDL04PyeZX/nNZYOAwlTzKmHq/JoFN6YoySi+0ZLyCtFrnRgw6zNnR/POXKOdfljWqZA==",
+      "requires": {
+        "@firebase/util": "1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@firebase/database": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.10.tgz",
+      "integrity": "sha512-QvKhWpsBK4T1L4iGOpTBRvw4s2nqEtD6qja+L116BejFFJZik+U+cVe3xLKoeyGy2YtbcS28ly0h285pmnYwRw==",
+      "requires": {
+        "@firebase/auth-interop-types": "0.1.5",
+        "@firebase/component": "0.4.1",
+        "@firebase/database-types": "0.7.2",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "1.0.0",
+        "faye-websocket": "0.11.3",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@firebase/database-types": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.2.tgz",
+      "integrity": "sha512-cdAd/dgwvC0r3oLEDUR+ULs1vBsEvy0b27nlzKhU6LQgm9fCDzgaH9nFGv8x+S9dly4B0egAXkONkVoWcOAisg==",
+      "requires": {
+        "@firebase/app-types": "0.6.2"
+      }
+    },
+    "@firebase/firestore": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.2.4.tgz",
+      "integrity": "sha512-0B4WNVYDusxURRclHHjw/OBLad7gerr25QGljQ0kkpeFEd6bYyoTUeGtP6YlYYog8KhxsR9R5f0NacuzQPS4OA==",
+      "requires": {
+        "@firebase/component": "0.4.1",
+        "@firebase/firestore-types": "2.2.0",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "1.0.0",
+        "@firebase/webchannel-wrapper": "0.4.1",
+        "@grpc/grpc-js": "^1.0.0",
+        "@grpc/proto-loader": "^0.5.0",
+        "node-fetch": "2.6.1",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@firebase/firestore-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.2.0.tgz",
+      "integrity": "sha512-5kZZtQ32FIRJP1029dw+ZVNRCclKOErHv1+Xn0pw/5Fq3dxroA/ZyFHqDu+uV52AyWHhNLjCqX43ibm4YqOzRw=="
+    },
+    "@firebase/functions": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.7.tgz",
+      "integrity": "sha512-IDw2ww28Tj8t947ySVO9wHghlwNl4bIUo5tPUzAbipfgLlj3GeHwqhvSv++O/ILBu4Rk7KD7cbxtw/rziATHNA==",
+      "requires": {
+        "@firebase/component": "0.4.1",
+        "@firebase/functions-types": "0.4.0",
+        "@firebase/messaging-types": "0.5.0",
+        "node-fetch": "2.6.1",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@firebase/functions-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.4.0.tgz",
+      "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ=="
+    },
+    "@firebase/installations": {
+      "version": "0.4.25",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.25.tgz",
+      "integrity": "sha512-szQ2bpI5NHTRuZAqXNZLq7bkZ1iTURPmojj7xWjBRxyMnDd6lLQ/Ht8Wut0ESH7uzbFNqmZ9oBMh2U9fpBIniA==",
+      "requires": {
+        "@firebase/component": "0.4.1",
+        "@firebase/installations-types": "0.3.4",
+        "@firebase/util": "1.0.0",
+        "idb": "3.0.2",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@firebase/installations-types": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.3.4.tgz",
+      "integrity": "sha512-RfePJFovmdIXb6rYwtngyxuEcWnOrzdZd9m7xAW0gRxDIjBT20n3BOhjpmgRWXo/DAxRmS7bRjWAyTHY9cqN7Q=="
+    },
+    "@firebase/logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
+      "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
+    },
+    "@firebase/messaging": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.9.tgz",
+      "integrity": "sha512-zzEmtpBdauT0n0JA5eN/dHeQZkQj/bbfl7CNmhA0EpKU2wTRFZCJYAOZkZEw8OD9/D/aDRcEk3Qq+5I1XcugZA==",
+      "requires": {
+        "@firebase/component": "0.4.1",
+        "@firebase/installations": "0.4.25",
+        "@firebase/messaging-types": "0.5.0",
+        "@firebase/util": "1.0.0",
+        "idb": "3.0.2",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@firebase/messaging-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.5.0.tgz",
+      "integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg=="
+    },
+    "@firebase/performance": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.11.tgz",
+      "integrity": "sha512-SQb9QpAkgpPS1QnRLxNAXFTCrW/VT9MidVcJVHuBrCCW9sYY+QVuuWYpaGR4zQDsTx2e/UGUXJgw+z0vaQ0Q6w==",
+      "requires": {
+        "@firebase/component": "0.4.1",
+        "@firebase/installations": "0.4.25",
+        "@firebase/logger": "0.2.6",
+        "@firebase/performance-types": "0.0.13",
+        "@firebase/util": "1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@firebase/performance-types": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.0.13.tgz",
+      "integrity": "sha512-6fZfIGjQpwo9S5OzMpPyqgYAUZcFzZxHFqOyNtorDIgNXq33nlldTL/vtaUZA8iT9TT5cJlCrF/jthKU7X21EA=="
+    },
+    "@firebase/polyfill": {
+      "version": "0.3.36",
+      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.36.tgz",
+      "integrity": "sha512-zMM9oSJgY6cT2jx3Ce9LYqb0eIpDE52meIzd/oe/y70F+v9u1LDqk5kUF5mf16zovGBWMNFmgzlsh6Wj0OsFtg==",
+      "requires": {
+        "core-js": "3.6.5",
+        "promise-polyfill": "8.1.3",
+        "whatwg-fetch": "2.0.4"
+      }
+    },
+    "@firebase/remote-config": {
+      "version": "0.1.36",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.36.tgz",
+      "integrity": "sha512-aQXaBDkEzFix3ycjPiP+4OPSXZmUbFunOiVi20XS9kRZrZfNhCH3HdBYwL1Nl9/AvcOnlZfX+lqa2LuHVXmuwA==",
+      "requires": {
+        "@firebase/component": "0.4.1",
+        "@firebase/installations": "0.4.25",
+        "@firebase/logger": "0.2.6",
+        "@firebase/remote-config-types": "0.1.9",
+        "@firebase/util": "1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@firebase/remote-config-types": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.1.9.tgz",
+      "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
+    },
+    "@firebase/storage": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.5.0.tgz",
+      "integrity": "sha512-nwIDikLEVzamuheZSRQbUbmMDITkPclCIokHR+4YbZsNNf7ukVN6PB8V/C8KMTjpDjSn9BOZbd9jF2U1VIgYqQ==",
+      "requires": {
+        "@firebase/component": "0.4.1",
+        "@firebase/storage-types": "0.4.0",
+        "@firebase/util": "1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@firebase/storage-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.4.0.tgz",
+      "integrity": "sha512-2xgiLGfDv6Fz5qRrsO47/7PfbV9P+5tEuvEktJYTNxrgTxGPj3sMb7ZkycIb4JE98fAbmGEeMQaRSorqR5bEIQ=="
+    },
+    "@firebase/util": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.0.0.tgz",
+      "integrity": "sha512-KIEyuyrYKKtit+lAl66c2GVvooM1Pb+Yw/9yuSga1HKYMxNZwSsIMXU8X97sLZf7WJaanV1XNJEMkZTw3xKEoA==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@firebase/webchannel-wrapper": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.1.tgz",
+      "integrity": "sha512-0yPjzuzGMkW1GkrC8yWsiN7vt1OzkMIi9HgxRmKREZl2wnNPOKo/yScTjXf/O57HM8dltqxPF6jlNLFVtc2qdw=="
+    },
+    "@grpc/grpc-js": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.12.tgz",
+      "integrity": "sha512-+gPCklP1eqIgrNPyzddYQdt9+GvZqPlLpIjIo+TveE+gbtp74VV1A2ju8ExeO8ma8f7MbpaGZx/KJPYVWL9eDw==",
+      "requires": {
+        "@types/node": ">=12.12.47",
+        "google-auth-library": "^6.1.1",
+        "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
+    "@grpc/proto-loader": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.6.tgz",
+      "integrity": "sha512-DT14xgw3PSzPxwS13auTEwxhMMOoz33DPUKNtmYK/QYbBSpLXJy78FGGs5yVoxVobEqPm4iW9MOIoz0A3bLTRQ==",
+      "requires": {
+        "lodash.camelcase": "^4.3.0",
+        "protobufjs": "^6.8.6"
+      }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -150,6 +553,11 @@
         "@types/node": "*"
       }
     },
+    "@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -165,8 +573,7 @@
     "@types/node": {
       "version": "14.0.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
-      "dev": true
+      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -179,6 +586,22 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -299,6 +722,16 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
@@ -342,6 +775,11 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "builtins": {
       "version": "1.0.3",
@@ -550,6 +988,11 @@
         "xdg-basedir": "^4.0.0"
       }
     },
+    "core-js": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+    },
     "cosmiconfig": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
@@ -585,6 +1028,14 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "dev": true
+    },
+    "debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "requires": {
+        "ms": "2.1.2"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -657,6 +1108,11 @@
         }
       }
     },
+    "dom-storage": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
+      "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q=="
+    },
     "dot-prop": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
@@ -671,6 +1127,14 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -714,6 +1178,11 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "execa": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
@@ -731,6 +1200,11 @@
         "strip-final-newline": "^2.0.0"
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -740,6 +1214,19 @@
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
+      }
+    },
+    "fast-text-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
+    },
+    "faye-websocket": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+      "requires": {
+        "websocket-driver": ">=0.5.1"
       }
     },
     "figures": {
@@ -770,11 +1257,53 @@
         "semver-regex": "^2.0.0"
       }
     },
+    "firebase": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.4.1.tgz",
+      "integrity": "sha512-PMDt9iU8ry5P7PSrGQ+72O1gkfa5rNAeybMZhP22nKOh40sVozSkcKGZAFumXog7tjlslHJhUEZgfZbKCNkC8Q==",
+      "requires": {
+        "@firebase/analytics": "0.6.9",
+        "@firebase/app": "0.6.20",
+        "@firebase/app-types": "0.6.2",
+        "@firebase/auth": "0.16.4",
+        "@firebase/database": "0.9.10",
+        "@firebase/firestore": "2.2.4",
+        "@firebase/functions": "0.6.7",
+        "@firebase/installations": "0.4.25",
+        "@firebase/messaging": "0.7.9",
+        "@firebase/performance": "0.4.11",
+        "@firebase/polyfill": "0.3.36",
+        "@firebase/remote-config": "0.1.36",
+        "@firebase/storage": "0.5.0",
+        "@firebase/util": "1.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "gaxios": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.2.0.tgz",
+      "integrity": "sha512-Ms7fNifGv0XVU+6eIyL9LB7RVESeML9+cMvkwGS70xyD6w2Z80wl6RiqiJ9k1KFlJCUTQqFFc8tXmPQfSKUe8g==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.3.0"
+      }
+    },
+    "gcp-metadata": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
+      "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
+      "requires": {
+        "gaxios": "^4.0.0",
+        "json-bigint": "^1.0.0"
+      }
     },
     "get-stream": {
       "version": "5.1.0",
@@ -835,6 +1364,50 @@
         }
       }
     },
+    "google-auth-library": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
+      "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
+      "requires": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "google-p12-pem": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
+      "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
+      "requires": {
+        "node-forge": "^0.10.0"
+      }
+    },
     "got": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -870,6 +1443,16 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
+    },
+    "gtoken": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+      "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
+      "requires": {
+        "gaxios": "^4.0.0",
+        "google-p12-pem": "^3.0.3",
+        "jws": "^4.0.0"
+      }
     },
     "hard-rejection": {
       "version": "2.1.0",
@@ -921,6 +1504,20 @@
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
     },
+    "http-parser-js": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg=="
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -953,6 +1550,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "idb": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
+      "integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw=="
     },
     "ignore": {
       "version": "5.1.8",
@@ -1352,8 +1954,7 @@
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "dev": true
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1413,6 +2014,14 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -1424,6 +2033,25 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
+    },
+    "jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "requires": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "keyv": {
       "version": "3.1.0",
@@ -1697,6 +2325,11 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
     "lodash.zip": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
@@ -1816,6 +2449,11 @@
           }
         }
       }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -1958,6 +2596,11 @@
       "integrity": "sha512-d2RKzMD4JNyHMbnbWnznPaa8vbdlq/4pNZ3IgdaGrVbBhebBsGUUE/6qorTMYNS6TwuH3ilfOlD2bf4Igh8CKg==",
       "dev": true
     },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "multimatch": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
@@ -2007,6 +2650,16 @@
           "dev": true
         }
       }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -2512,6 +3165,38 @@
         }
       }
     },
+    "promise-polyfill": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
+    },
+    "protobufjs": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
+      "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": "^13.7.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.48",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.48.tgz",
+          "integrity": "sha512-z8wvSsgWQzkr4sVuMEEOvwMdOQjiRY2Y/ZW4fDfjfe3+TfQrZqFKOthBgk2RnVEmtOKrkwdZ7uTvsxTBLjKGDQ=="
+        }
+      }
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -2695,6 +3380,11 @@
       "requires": {
         "tslib": "^1.9.0"
       }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -3038,6 +3728,26 @@
         "builtins": "^1.0.3"
       }
     },
+    "websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "requires": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
+    },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3128,6 +3838,11 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "author": "Priyank Patel <priyank.patel@stackspace.ca>",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/core": "latest"
+    "@capacitor/core": "latest",
+    "firebase": "^8.4.1"
   },
   "devDependencies": {
     "@capacitor/android": "latest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joinflux/firebase-analytics",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A native plugin for firebase analytics.",
   "homepage": "https://github.com/joinflux/firebase-analytics",
   "main": "dist/esm/index.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -5,7 +5,6 @@ declare module "@capacitor/core" {
 }
 
 export interface FirebaseAnalyticsPlugin {
-  initializeFirebase(options: FirebaseInitOptions): Promise<any>;
   setUserId(options: { userId: string }): Promise<void>;
   setUserProperty(options: { name: string; value: string }): Promise<void>;
   getAppInstanceId(): Promise<{ instanceId: string }>;
@@ -18,15 +17,4 @@ export interface FirebaseAnalyticsPlugin {
   setCollectionEnabled(options: { enabled: boolean }): Promise<void>;
   enable(): Promise<void>;
   disable(): Promise<void>;
-}
-
-export interface FirebaseInitOptions {
-  apiKey: string;
-  authDomain: string;
-  databaseURL: string;
-  projectId: string;
-  storageBucket: string;
-  messagingSenderId: string;
-  appId: string;
-  measurementId: string;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,3 +1,5 @@
+import firebase from "firebase";
+
 declare module "@capacitor/core" {
   interface PluginRegistry {
     FirebaseAnalytics: FirebaseAnalyticsPlugin;
@@ -5,6 +7,7 @@ declare module "@capacitor/core" {
 }
 
 export interface FirebaseAnalyticsPlugin {
+  initializeFirebase(app: firebase.app.App): Promise<void>;
   setUserId(options: { userId: string }): Promise<void>;
   setUserProperty(options: { name: string; value: string }): Promise<void>;
   getAppInstanceId(): Promise<{ instanceId: string }>;

--- a/src/web.ts
+++ b/src/web.ts
@@ -110,13 +110,6 @@ export class FirebaseAnalyticsWeb extends WebPlugin
     return;
   }
 
-  /**
-   * Returns analytics reference object
-   */
-  get remoteConfig() {
-    return this.analyticsRef;
-  }
-
   async enable(): Promise<void> {
     this.analyticsRef.setAnalyticsCollectionEnabled(true);
     return;

--- a/src/web.ts
+++ b/src/web.ts
@@ -12,10 +12,10 @@ export class FirebaseAnalyticsWeb extends WebPlugin
       name: "FirebaseAnalytics",
       platforms: ["web"],
     });
+  }
 
-    if (!firebase.app())
-      throw new Error("missing firebase app, plase initialize firebase first");
-    this.analyticsRef = firebase.analytics();
+  async initializeFirebase(app: firebase.app.App) {
+    this.analyticsRef = app.analytics();
   }
 
   /**

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,34 +1,11 @@
-import { WebPlugin } from "@capacitor/core";
-
-import { FirebaseAnalyticsPlugin, FirebaseInitOptions } from "./definitions";
-
-declare var window: any;
-
-// Errors
-const ErrFirebaseAnalyticsMissing = new Error(
-  "Firebase analytics is not initialized. Make sure initializeFirebase() is called once"
-);
-const ErrOptionsMissing = new Error("Firebase options are missing");
-
-// Firebase Library Version
-const FIREBASE_VERSION = "8.3.0";
+import { registerWebPlugin, WebPlugin } from "@capacitor/core";
+import firebase from "firebase";
+import "firebase/analytics";
+import { FirebaseAnalyticsPlugin } from "./definitions";
 
 export class FirebaseAnalyticsWeb extends WebPlugin
   implements FirebaseAnalyticsPlugin {
-  public readonly ready: Promise<any>;
-  private readyResolver: Function;
-  private analyticsRef: any;
-
-  private scripts = [
-    {
-      key: "firebase-app",
-      src: `https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/firebase-app.js`,
-    },
-    {
-      key: "firebase-ac",
-      src: `https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/firebase-analytics.js`,
-    },
-  ];
+  private analyticsRef: firebase.analytics.Analytics;
 
   constructor() {
     super({
@@ -36,8 +13,9 @@ export class FirebaseAnalyticsWeb extends WebPlugin
       platforms: ["web"],
     });
 
-    this.ready = new Promise((resolve) => (this.readyResolver = resolve));
-    this.loadScripts();
+    if (!firebase.app())
+      throw new Error("missing firebase app, plase initialize firebase first");
+    this.analyticsRef = firebase.analytics();
   }
 
   /**
@@ -46,9 +24,6 @@ export class FirebaseAnalyticsWeb extends WebPlugin
    * Platform: Web/Android/iOS
    */
   async setUserId(options: { userId: string }): Promise<void> {
-    await this.ready;
-
-    if (!this.analyticsRef) throw ErrFirebaseAnalyticsMissing;
     if (!options?.userId) throw new Error("userId property is missing");
 
     this.analyticsRef.setUserId(options.userId);
@@ -65,14 +40,9 @@ export class FirebaseAnalyticsWeb extends WebPlugin
     name: string;
     value: string;
   }): Promise<void> {
-    await this.ready;
-
-    if (!this.analyticsRef) throw ErrFirebaseAnalyticsMissing;
-
     const { name, value } = options || { name: undefined, value: undefined };
 
     if (!name) throw new Error("name property is missing");
-
     if (!value) throw new Error("value property is missing");
 
     let property: any = {};
@@ -118,10 +88,6 @@ export class FirebaseAnalyticsWeb extends WebPlugin
    * Platform: Web/Android/iOS
    */
   async logEvent(options: { name: string; params: object }): Promise<void> {
-    await this.ready;
-
-    if (!this.analyticsRef) throw ErrFirebaseAnalyticsMissing;
-
     const { name, params } = options || {
       name: undefined,
       params: undefined,
@@ -139,10 +105,6 @@ export class FirebaseAnalyticsWeb extends WebPlugin
    * Platform: Web/Android/iOS
    */
   async setCollectionEnabled(options: { enabled: boolean }): Promise<void> {
-    await this.ready;
-
-    if (!this.analyticsRef) throw ErrFirebaseAnalyticsMissing;
-
     const { enabled = false } = options;
     this.analyticsRef.setAnalyticsCollectionEnabled(enabled);
     return;
@@ -156,86 +118,13 @@ export class FirebaseAnalyticsWeb extends WebPlugin
   }
 
   async enable(): Promise<void> {
-    await this.ready;
-
-    if (!this.analyticsRef) throw ErrFirebaseAnalyticsMissing;
-
     this.analyticsRef.setAnalyticsCollectionEnabled(true);
     return;
   }
 
   async disable(): Promise<void> {
-    await this.ready;
-
-    if (!this.analyticsRef) throw ErrFirebaseAnalyticsMissing;
-
     this.analyticsRef.setAnalyticsCollectionEnabled(false);
     return;
-  }
-
-  /**
-   * Configure and Initialize FirebaseApp if not present
-   * @param options - web app's Firebase configuration
-   * @returns firebase analytics object reference
-   * Platform: Web
-   */
-  async initializeFirebase(options: FirebaseInitOptions): Promise<any> {
-    if (!options) throw ErrOptionsMissing;
-
-    await this.firebaseObjectReadyPromise();
-    const app = this.isFirebaseInitialized()
-      ? window.firebase
-      : window.firebase.initializeApp(options);
-    this.analyticsRef = app.analytics();
-    this.readyResolver();
-    return this.analyticsRef;
-  }
-
-  /**
-   * Check for existing loaded script and load new scripts
-   */
-  private loadScripts(): Promise<Array<any>> {
-    return Promise.all(this.scripts.map((s) => this.loadScript(s.key, s.src)));
-  }
-
-  /**
-   * Loaded single script with provided id and source
-   * @param id - unique identifier of the script
-   * @param src - source of the script
-   */
-  private loadScript(id: string, src: string): Promise<any> {
-    return new Promise((resolve, reject) => {
-      if (document.getElementById(id)) {
-        resolve(null);
-      } else {
-        const file = document.createElement("script");
-        file.type = "text/javascript";
-        file.src = src;
-        file.id = id;
-        file.onload = resolve;
-        file.onerror = reject;
-        document.querySelector("head").appendChild(file);
-      }
-    });
-  }
-
-  private firebaseObjectReadyPromise(): Promise<void> {
-    var tries = 100;
-    return new Promise((resolve, reject) => {
-      const interval = setInterval(() => {
-        if (window.firebase?.analytics) {
-          clearInterval(interval);
-          resolve(null);
-        } else if (tries-- <= 0) {
-          reject("Firebase fails to load");
-        }
-      }, 50);
-    });
-  }
-
-  private isFirebaseInitialized() {
-    const length = window.firebase?.apps?.length;
-    return length && length > 0;
   }
 }
 
@@ -243,5 +132,4 @@ const FirebaseAnalytics = new FirebaseAnalyticsWeb();
 
 export { FirebaseAnalytics };
 
-import { registerWebPlugin } from "@capacitor/core";
 registerWebPlugin(FirebaseAnalytics);


### PR DESCRIPTION
We are preferring using the SDK directly in favour of adding the scripts
to the DOM. This is due to the fact that loading the script by adding
them to the DOM is unreliable and provides potential sources of
conflicts with other Firebase related Capacitor plugins.
